### PR TITLE
Allow websocket peer creation with ConnectConfig

### DIFF
--- a/realm.go
+++ b/realm.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	logrus "github.com/sirupsen/logrus"
-	"github.com/streamrail/concurrent-map"
+	cmap "github.com/streamrail/concurrent-map"
 )
 
 const (
@@ -192,7 +192,7 @@ func (r *Realm) doOne(c <-chan Message, sess *Session) bool {
 		}
 
 	default:
-		log.Warningf("Unhandled message:", msg.MessageType())
+		log.Warning("Unhandled message:", msg.MessageType())
 	}
 	return true
 }

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -129,7 +129,7 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO: subprotocol?
 	conn, err := s.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Errorf("Error upgrading to websocket connection:", err)
+		log.Error("Error upgrading to websocket connection:", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
We need this to be able to set `PingTimeout` (by default it's a week) which looks like is the cause of a huge amount of running go routines in services that keep reconnecting to the router. We experienced this on Tuesday July 16th:

```
goroutine profile: total 81826
81673 @ 0x42c9da 0x43c550 0xb4502a 0x45a0c1
#	0xb45029	github.com/digitallumens/lightworks_data_processor/vendor/github.com/digitallumens/turnpike.(*websocketPeer).sending+0x1e9	/go/src/github.com/digitallumens/lightworks_data_processor/vendor/github.com/digitallumens/turnpike/websocket.go:214

```

The problem is with the following ticker: https://github.com/digitallumens/turnpike/blob/v2/websocket.go#L219
It ticks once per week and there is no way of changing its interval. The effect is that when we reconnect and we close the client this go routine is alive for another week. If we reconnect often then the number of idle go routines will grow.

It worries me that tests don't work on current v2 branch